### PR TITLE
first shot at code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS file allows to publicly render the code owners visible.
+# Might be useful contributers who whom to contact for issues
+# or PRs
+# check https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for more info about CODEOWNERS
+
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @feenes @klausfmh @MHComm @Zluurk


### PR DESCRIPTION
more transparency by using CODEOWNERS

Hope I understood the syntax.

Pls crosscheck with https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners when reading this PR